### PR TITLE
Optional SDXL-Turbo Size Tweak

### DIFF
--- a/aws-cdk/lambdas/painting-create.ts
+++ b/aws-cdk/lambdas/painting-create.ts
@@ -49,11 +49,11 @@ export const createPainting = async (event: APIGatewayProxyEventV2WithJWTAuthori
                     {
                         "type": "dictionary",
                         "value": {
-                            "height": 768,
+                            "height": 384,
                             "num_images_per_prompt": 1,
                             "num_inference_steps": 4,
                             "strength": 0.8,
-                            "width": 1024
+                            "width": 512
                         }
                     }
                 ]


### PR DESCRIPTION
sdxl-turbo doesn't behave well when generating images larger than 512x512.
I think the images would still look fine at half the size and stretched?  You could also send the 512x384 to an upscaler as an extra step, or just use sdxl which generates at 1024x1024 https://www.mystic.ai/ainzoil/sd-xl/play but both would add an extra cost or extra request time.

Depends on if the doubling/mirroring is a bug or a feature of the bad art gallery:
![image](https://github.com/hello-adam/dumb-art-gallery/assets/4807250/9d8d4c13-24f9-437b-bacd-9bfd64348f17)
